### PR TITLE
Add version constraint for Terraform provider (hcloud)

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
+      version = ">= 1.0.0, < 2.0.0"
     }
   }
 }


### PR DESCRIPTION
The next major release might contain some changes that are not backwards compatible. 