### PR TITLE
Prevent secrets from being exposed

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
 variable "hcloud_token" {
-  description = "Hetzner API tokey"
+  description = "Hetzner Cloud API Token"
   type        = string
+  sensitive   = true
 }
 
 variable "public_key" {


### PR DESCRIPTION
The Hetzner API token should not be exposed in case of any errors, as you can see at #8.