### PR TITLE
make private key optional to support hardware tokens for SSH

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -28,7 +28,8 @@ resource "hcloud_server" "agents" {
 
     connection {
       user        = "root"
-      private_key = file(var.private_key)
+      private_key = var.private_key == null ? null : file(var.private_key)
+      agent_identity = var.private_key == null ? file(var.public_key) : null
       host        = self.ipv4_address
     }
   }
@@ -39,7 +40,8 @@ resource "hcloud_server" "agents" {
 
     connection {
       user        = "root"
-      private_key = file(var.private_key)
+      private_key = var.private_key == null ? null : file(var.private_key)
+      agent_identity = var.private_key == null ? file(var.public_key) : null
       host        = self.ipv4_address
     }
   }

--- a/master.tf
+++ b/master.tf
@@ -24,7 +24,8 @@ resource "hcloud_server" "first_control_plane" {
 
     connection {
       user        = "root"
-      private_key = file(var.private_key)
+      private_key = var.private_key == null ? null : file(var.private_key)
+      agent_identity = var.private_key == null ? file(var.public_key) : null
       host        = self.ipv4_address
     }
   }
@@ -35,7 +36,8 @@ resource "hcloud_server" "first_control_plane" {
 
     connection {
       user        = "root"
-      private_key = file(var.private_key)
+      private_key = var.private_key == null ? null : file(var.private_key)
+      agent_identity = var.private_key == null ? file(var.public_key) : null
       host        = self.ipv4_address
     }
   }
@@ -43,7 +45,7 @@ resource "hcloud_server" "first_control_plane" {
   # Wait for k3os to be ready and fetch kubeconfig.yaml
   provisioner "local-exec" {
     command = <<-EOT
-      sleep 60 && ping ${self.ipv4_address} | grep --line-buffered "bytes from" | head -1 && sleep 100 && scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${var.private_key} rancher@${self.ipv4_address}:/etc/rancher/k3s/k3s.yaml ${path.module}/kubeconfig.yaml
+      sleep 60 && ping ${self.ipv4_address} | grep --line-buffered "bytes from" | head -1 && sleep 100 && scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${var.private_key == null ? var.public_key : var.private_key} rancher@${self.ipv4_address}:/etc/rancher/k3s/k3s.yaml ${path.module}/kubeconfig.yaml
       sed -i -e 's/127.0.0.1/${self.ipv4_address}/g' ${path.module}/kubeconfig.yaml
     EOT
   }

--- a/servers.tf
+++ b/servers.tf
@@ -27,7 +27,8 @@ resource "hcloud_server" "control_planes" {
 
     connection {
       user        = "root"
-      private_key = file(var.private_key)
+      private_key = var.private_key == null ? null : file(var.private_key)
+      agent_identity = var.private_key == null ? file(var.public_key) : null
       host        = self.ipv4_address
     }
   }
@@ -38,7 +39,8 @@ resource "hcloud_server" "control_planes" {
 
     connection {
       user        = "root"
-      private_key = file(var.private_key)
+      private_key = var.private_key == null ? null : file(var.private_key)
+      agent_identity = var.private_key == null ? file(var.public_key) : null
       host        = self.ipv4_address
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,7 @@ variable "public_key" {
 variable "private_key" {
   description = "SSH private Key."
   type        = string
+  default     = null
 }
 
 variable "location" {


### PR DESCRIPTION
Hi & thanks for this fantastic project!

I'd like to use a yubikey for authentication with my cluster, so I don't have a private ssh key lying on my disk, only on the token. The way that normally works is that I just use my local ssh-agent and pass the needed ssh identity as a *public* key to the agent. The following PR supports that workflow if private_key is set to `null`.

It currently duplicates the logic in 3 files to keep it simple, but I could also introduce `local.private_key` and `local.agent_identity` to deduplicate if you wish so.
What do you think, is this a viable approach?