### PR TITLE
remove empty provider blocks

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,3 @@
-provider "github" {}
-
 provider "hcloud" {
   token = var.hcloud_token
 }
-
-provider "local" {}


### PR DESCRIPTION
terraform v1.1.4 (and at least v1.0.11) emits a warning for empty
provider blocks. Removing those still seems to work while avoiding
that warning.