### PR TITLE
ingress: don't use private ip, make ipv6 optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -166,8 +166,9 @@ resource "local_file" "hetzner_csi_config" {
 
 resource "local_file" "traefik_config" {
   content = templatefile("${path.module}/templates/traefik_config.yaml.tpl", {
-    lb_server_type = var.lb_server_type
-    location       = var.location
+    lb_disable_ipv6 = var.lb_disable_ipv6
+    lb_server_type  = var.lb_server_type
+    location        = var.location
   })
   filename             = "${path.module}/templates/rendered/traefik_config.yaml"
   file_permission      = "0644"

--- a/templates/traefik_config.yaml.tpl
+++ b/templates/traefik_config.yaml.tpl
@@ -10,7 +10,12 @@ spec:
       type: LoadBalancer
       annotations:
         "load-balancer.hetzner.cloud/name": "traefik"
+        # make hetzners load-balancer connect to our nodes via our private k3s-net.
         "load-balancer.hetzner.cloud/use-private-ip": "true"
+        # keep hetzner-ccm from exposing our private ingress ip, which in general isn't routeable from the public internet.
+        "load-balancer.hetzner.cloud/disable-private-ingress": "true"
+        # disable ipv6 by default, because external-dns doesn't support AAAA for hcloud yet https://github.com/kubernetes-sigs/external-dns/issues/2044
+        "load-balancer.hetzner.cloud/ipv6-disabled": "${lb_disable_ipv6}"
         "load-balancer.hetzner.cloud/location": "${location}"
         "load-balancer.hetzner.cloud/type": "${lb_server_type}"
         "load-balancer.hetzner.cloud/uses-proxyprotocol": "true"

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,12 @@ variable "lb_server_type" {
   type        = string
 }
 
+variable "lb_disable_ipv6" {
+  description = "Disable ipv6 for the load balancer"
+  type        = bool
+  default     = false
+}
+
 variable "servers_num" {
   description = "Number of control plane nodes."
   type        = number


### PR DESCRIPTION
The rationale for this PR has been documented in https://github.com/kube-hetzner/kube-hetzner/issues/18#issuecomment-1019993588. I believe that usage of kube-hetzner together with external-dns is broken without this settings - using cloudflare proxying just hides the issues, because cloudflare seems to filter the private IP automatically.
With this PR it should work both, with or without proxying as well as for other DNS providers supported by external-dns