### PR TITLE
Use variable for network region

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "hcloud_network" "k3s" {
 resource "hcloud_network_subnet" "k3s" {
   network_id   = hcloud_network.k3s.id
   type         = "cloud"
-  network_zone = "eu-central"
+  network_zone = var.network_region
   ip_range     = "10.0.0.0/16"
 }
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -7,7 +7,8 @@ private_key  = "/home/username/.ssh/id_ed25519"
 # These can be customized, or left with the default values
 # For Hetzner locations see https://docs.hetzner.com/general/others/data-centers-and-connection/
 # For Hetzner server types see https://www.hetzner.com/cloud
-location                  = "fsn1"
+location                  = "fsn1" # change to `ash` for us-east Ashburn, Virginia location
+network_region            = "eu-central" # change to `us-east` if location is ash
 agent_server_type         = "cpx21"
 control_plane_server_type = "cpx11"
 lb_server_type            = "lb11"

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,11 @@ variable "location" {
   type        = string
 }
 
+variable "network_region" {
+  description = "Default region for network"
+  type        = string
+}
+
 variable "control_plane_server_type" {
   description = "Default control plane server type"
   type        = string


### PR DESCRIPTION
Instead of hard-coding the network into `eu-central`, this allows the user to set the network region in the main config