### PR TITLE
Add Hetzner placement group and link servers to it

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -2,12 +2,13 @@ resource "hcloud_server" "agents" {
   count = var.agents_num
   name  = "k3s-agent-${count.index}"
 
-  image        = data.hcloud_image.linux.name
-  rescue       = "linux64"
-  server_type  = var.agent_server_type
-  location     = var.location
-  ssh_keys     = [hcloud_ssh_key.default.id]
-  firewall_ids = [hcloud_firewall.k3s.id]
+  image              = data.hcloud_image.linux.name
+  rescue             = "linux64"
+  server_type        = var.agent_server_type
+  location           = var.location
+  ssh_keys           = [hcloud_ssh_key.default.id]
+  firewall_ids       = [hcloud_firewall.k3s.id]
+  placement_group_id = hcloud_placement_group.k3s_placement_group.id
 
 
   labels = {

--- a/main.tf
+++ b/main.tf
@@ -174,3 +174,13 @@ resource "local_file" "traefik_config" {
   file_permission      = "0644"
   directory_permission = "0755"
 }
+
+
+resource "hcloud_placement_group" "k3s_placement_group" {
+  name = "k3s-placement-group"
+  type = "spread"
+  labels = {
+    "provisioner" = "terraform",
+    "engine"      = "k3s"
+  }
+}

--- a/master.tf
+++ b/master.tf
@@ -1,12 +1,13 @@
 resource "hcloud_server" "first_control_plane" {
   name = "k3s-control-plane-0"
 
-  image        = data.hcloud_image.linux.name
-  rescue       = "linux64"
-  server_type  = var.control_plane_server_type
-  location     = var.location
-  ssh_keys     = [hcloud_ssh_key.default.id]
-  firewall_ids = [hcloud_firewall.k3s.id]
+  image              = data.hcloud_image.linux.name
+  rescue             = "linux64"
+  server_type        = var.control_plane_server_type
+  location           = var.location
+  ssh_keys           = [hcloud_ssh_key.default.id]
+  firewall_ids       = [hcloud_firewall.k3s.id]
+  placement_group_id = hcloud_placement_group.k3s_placement_group.id
 
   labels = {
     "provisioner" = "terraform",

--- a/servers.tf
+++ b/servers.tf
@@ -2,12 +2,13 @@ resource "hcloud_server" "control_planes" {
   count = var.servers_num - 1
   name  = "k3s-control-plane-${count.index + 1}"
 
-  image        = data.hcloud_image.linux.name
-  rescue       = "linux64"
-  server_type  = var.control_plane_server_type
-  location     = var.location
-  ssh_keys     = [hcloud_ssh_key.default.id]
-  firewall_ids = [hcloud_firewall.k3s.id]
+  image              = data.hcloud_image.linux.name
+  rescue             = "linux64"
+  server_type        = var.control_plane_server_type
+  location           = var.location
+  ssh_keys           = [hcloud_ssh_key.default.id]
+  firewall_ids       = [hcloud_firewall.k3s.id]
+  placement_group_id = hcloud_placement_group.k3s_placement_group.id
 
   labels = {
     "provisioner" = "terraform",


### PR DESCRIPTION
it is important to use placement group for HA deployment, from Hetzner Cloud doc they are used to influence the distribution of interdependent virtual servers in their data centers.

In spread placement groups, all virtual servers are running on different physical servers. This decreases the probability that some instances might fail together.