### PR TITLE
Configure eth1 and set hostname

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -13,7 +13,7 @@ locals {
 
   microOS_install_commands = [
     "set -ex",
-    "apt install -y aria2",
+    "apt-get install -y aria2",
     "aria2c  --follow-metalink=mem https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-k3s-kvm-and-xen.qcow2.meta4",
     "qemu-img convert -p -f qcow2 -O host_device $(ls -a | grep -ie '^opensuse.*microos.*k3s.*qcow2$') /dev/sda",
     "sgdisk -e /dev/sda",

--- a/master.tf
+++ b/master.tf
@@ -33,6 +33,7 @@ resource "hcloud_server" "first_control_plane" {
 
   provisioner "file" {
     content = templatefile("${path.module}/templates/config.ign.tpl", {
+      name           = self.name
       ssh_public_key = local.ssh_public_key
     })
     destination = "/root/config.ign"

--- a/templates/config.ign.tpl
+++ b/templates/config.ign.tpl
@@ -11,5 +11,21 @@
         ]
       }
     ]
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/hostname",
+        "mode": 420,
+        "overwrite": true,
+        "contents": { "source": "data:,${name}" }
+      },
+      {
+        "path": "/etc/sysconfig/network/ifcfg-eth1",
+        "mode": 420,
+        "overwrite": true,
+        "contents": { "source": "data:,BOOTPROTO%3D%27dhcp%27%0ASTARTMODE%3D%27auto%27" }
+      }
+    ]
   }
 }


### PR DESCRIPTION
Use ignition file to set up eth1 and to set the hostname.

Also, change the aria2 installation from `apt` to `apt-get` because the latter doesn't use fancy terminal features that clutter terraform output.