### PR TITLE
Really disable servicelb

### DIFF
--- a/templates/master_config.yaml.tpl
+++ b/templates/master_config.yaml.tpl
@@ -1,7 +1,8 @@
 cluster-init: true
 disable-cloud-controller: true
-disable: servicelb 
-disable: local-storage
+disable:
+- servicelb
+- local-storage
 flannel-iface: eth1
 node-ip: ${node_ip}
 advertise-address: ${node_ip}

--- a/templates/server_config.yaml.tpl
+++ b/templates/server_config.yaml.tpl
@@ -1,7 +1,8 @@
 server: ${first_control_plane_url}
 disable-cloud-controller: true
-disable: servicelb 
-disable: local-storage
+disable:
+- servicelb
+- local-storage
 flannel-iface: eth1
 node-ip: ${node_ip}
 advertise-address: ${node_ip}


### PR DESCRIPTION
YAML syntax does not allow multiple fields with the same key; the last one overrides all the previous.