### PR TITLE
Taint control-plane nodes with node-role.kubernetes.io/master:NoSchedule

### DIFF
--- a/templates/master_config.yaml.tpl
+++ b/templates/master_config.yaml.tpl
@@ -9,3 +9,5 @@ tls-san: ${node_ip}
 kubelet-arg: "cloud-provider=external"
 token: ${token}
 node-name: ${node_name}
+node-taint:
+- node-role.kubernetes.io/master:NoSchedule

--- a/templates/server_config.yaml.tpl
+++ b/templates/server_config.yaml.tpl
@@ -9,3 +9,5 @@ tls-san: ${node_ip}
 kubelet-arg: "cloud-provider=external"
 token: ${token}
 node-name: ${node_name}
+node-taint:
+- node-role.kubernetes.io/master:NoSchedule


### PR DESCRIPTION
That is the expected status when you create a cluster with most of the deployment systems (i.e., kubeadm or kind)

Fix #39