### PR TITLE
fix ssh identity in staging

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -45,12 +45,12 @@ resource "hcloud_server" "agents" {
 
   # Issue a reboot command
   provisioner "local-exec" {
-    command = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root ${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3"
+    command = "ssh ${local.ssh_args} ${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3"
   }
 
   # Wait for MicroOS to reboot and be ready
   provisioner "local-exec" {
-    command = "until ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root -o ConnectTimeout=2 ${self.ipv4_address} true; do sleep 1; done"
+    command = "until ssh ${local.ssh_args} -o ConnectTimeout=2 ${self.ipv4_address} true; do sleep 1; done"
   }
 
   # Generating and uploading the angent.conf file

--- a/agents.tf
+++ b/agents.tf
@@ -45,12 +45,12 @@ resource "hcloud_server" "agents" {
 
   # Issue a reboot command
   provisioner "local-exec" {
-    command = "ssh ${local.ssh_args} ${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3"
+    command = "ssh ${local.ssh_args} root@${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3"
   }
 
   # Wait for MicroOS to reboot and be ready
   provisioner "local-exec" {
-    command = "until ssh ${local.ssh_args} -o ConnectTimeout=2 ${self.ipv4_address} true; do sleep 1; done"
+    command = "until ssh ${local.ssh_args} -o ConnectTimeout=2 root@${self.ipv4_address} true; do sleep 1; done"
   }
 
   # Generating and uploading the angent.conf file

--- a/locals.tf
+++ b/locals.tf
@@ -11,6 +11,9 @@ locals {
   # if an ssh agent is used.
   ssh_identity_file = var.private_key == null ? var.public_key : var.private_key
 
+  # shared flags for ssh to ignore host keys, to use root and our ssh identity file for all connections during provisioning.
+  ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root -i ${local.ssh_identity_file}"
+
   MicroOS_install_commands = [
     "set -ex",
     "apt-get install -y aria2",

--- a/locals.tf
+++ b/locals.tf
@@ -12,7 +12,7 @@ locals {
   ssh_identity_file = var.private_key == null ? var.public_key : var.private_key
 
   # shared flags for ssh to ignore host keys, to use root and our ssh identity file for all connections during provisioning.
-  ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root -i ${local.ssh_identity_file}"
+  ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${local.ssh_identity_file}"
 
   MicroOS_install_commands = [
     "set -ex",

--- a/master.tf
+++ b/master.tf
@@ -43,12 +43,12 @@ resource "hcloud_server" "first_control_plane" {
 
   # Issue a reboot command
   provisioner "local-exec" {
-    command = "ssh ${local.ssh_args} ${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3"
+    command = "ssh ${local.ssh_args} root@${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3"
   }
 
   # Wait for MicroOS to reboot and be ready
   provisioner "local-exec" {
-    command = "until ssh ${local.ssh_args} -o ConnectTimeout=2 ${self.ipv4_address} true; do sleep 1; done"
+    command = "until ssh ${local.ssh_args} -o ConnectTimeout=2 root@${self.ipv4_address} true; do sleep 1; done"
   }
 
   # Generating k3s master config file
@@ -90,7 +90,7 @@ resource "hcloud_server" "first_control_plane" {
     command = <<-EOT
       set -ex
       sleep 30
-      scp ${local.ssh_args} ${self.ipv4_address}:/etc/rancher/k3s/k3s.yaml ${path.module}/kubeconfig.yaml
+      scp ${local.ssh_args} root@${self.ipv4_address}:/etc/rancher/k3s/k3s.yaml ${path.module}/kubeconfig.yaml
       sed -i -e 's/127.0.0.1/${self.ipv4_address}/g' ${path.module}/kubeconfig.yaml
       sleep 10 && until kubectl get node ${self.name}; do sleep 5; done
     EOT

--- a/servers.tf
+++ b/servers.tf
@@ -44,12 +44,12 @@ resource "hcloud_server" "control_planes" {
 
   # Issue a reboot command
   provisioner "local-exec" {
-    command = "ssh ${local.ssh_args} ${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3"
+    command = "ssh ${local.ssh_args} root@${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3"
   }
 
   # Wait for MicroOS to reboot and be ready
   provisioner "local-exec" {
-    command = "until ssh ${local.ssh_args} -o ConnectTimeout=2 ${self.ipv4_address} true; do sleep 1; done"
+    command = "until ssh ${local.ssh_args} -o ConnectTimeout=2 root@${self.ipv4_address} true; do sleep 1; done"
   }
 
   # Generating k3s server config file

--- a/servers.tf
+++ b/servers.tf
@@ -44,12 +44,12 @@ resource "hcloud_server" "control_planes" {
 
   # Issue a reboot command
   provisioner "local-exec" {
-    command = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root ${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3"
+    command = "ssh ${local.ssh_args} ${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3"
   }
 
   # Wait for MicroOS to reboot and be ready
   provisioner "local-exec" {
-    command = "until ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root -o ConnectTimeout=2 ${self.ipv4_address} true; do sleep 1; done"
+    command = "until ssh ${local.ssh_args} -o ConnectTimeout=2 ${self.ipv4_address} true; do sleep 1; done"
   }
 
   # Generating k3s server config file


### PR DESCRIPTION
Newly added ssh commands were missing the flag -i to pass an
identity file. This means that those commands use different
settings then the provisioners and their connection blocks
around them.

While adding this parameter, I decided it would be cleanest
to add local.ssh_args.