### PR TITLE
fix: openSUSE url

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -17,7 +17,7 @@ locals {
   MicroOS_install_commands = [
     "set -ex",
     "apt-get install -y aria2",
-    "aria2c --follow-metalink=mem https://raw.githubusercontent.com/kube-hetzner/kube-hetzner/staging/.files/openSUSE-MicroOS.x86_64-k3s-kvm-and-xen.qcow2.meta4",
+    "aria2c --follow-metalink=mem https://raw.githubusercontent.com/kube-hetzner/kube-hetzner/master/.files/openSUSE-MicroOS.x86_64-k3s-kvm-and-xen.qcow2.meta4",
     "qemu-img convert -p -f qcow2 -O host_device $(ls -a | grep -ie '^opensuse.*microos.*k3s.*qcow2$') /dev/sda",
     "sgdisk -e /dev/sda",
     "parted -s /dev/sda resizepart 4 99%",


### PR DESCRIPTION
Fixed use of openSUSE for the master branch, not the staging