### PR TITLE
Expose load balancer ip

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -156,5 +156,5 @@ resource "hcloud_placement_group" "k3s" {
 data "hcloud_load_balancer" "traefik" {
   name = "traefik"
 
-  depends_on = [ hcloud_server.first_control_plane ]
+  depends_on = [hcloud_server.first_control_plane]
 }

--- a/main.tf
+++ b/main.tf
@@ -155,4 +155,6 @@ resource "hcloud_placement_group" "k3s" {
 
 data "hcloud_load_balancer" "traefik" {
   name = "traefik"
+
+  depends_on = [ hcloud_server.first_control_plane ]
 }

--- a/main.tf
+++ b/main.tf
@@ -152,3 +152,7 @@ resource "hcloud_placement_group" "k3s" {
     "engine"      = "k3s"
   }
 }
+
+data "hcloud_load_balancer" "traefik" {
+  name = "traefik"
+}

--- a/output.tf
+++ b/output.tf
@@ -10,7 +10,7 @@ output "agents_public_ip" {
 
 output "load_balancer_public_ip" {
   description = "The public IPv4 address of the Hetzner load balancer"
-  value = data.hcloud_load_balancer.traefik.ipv4
+  value       = data.hcloud_load_balancer.traefik.ipv4
 }
 
 output "kubeconfig_file" {

--- a/output.tf
+++ b/output.tf
@@ -8,6 +8,11 @@ output "agents_public_ip" {
   description = "The public IP addresses of the agent server."
 }
 
+output "load_balancer_public_ip" {
+  description = "The public IPv4 address of the Hetzner load balancer"
+  value = data.hcloud_load_balancer.traefik.ipv4
+}
+
 output "kubeconfig_file" {
   value       = local.kubeconfig_external
   description = "Kubeconfig file content with external IP address"


### PR DESCRIPTION
Hi,

So this is not 100% percent solid, as data.hcloud_load_balancer depends on the load balancer being deployed quick enough after CCM deployment is started - but it worked for me in practice on three runs and I think it's really useful to have this external endpoint in terraforms output.