### PR TITLE
adds support for inline ssh keys

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -37,22 +37,27 @@ resource "hcloud_server" "agents" {
   }
 
   # Issue a reboot command
-  provisioner "local-exec" {
-    command = "ssh ${local.ssh_args} root@${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3"
+  provisioner "remote-exec" {
+    inline = [
+      "sleep 2",
+      "reboot"
+    ]
+    # reboot doesn't return a proper exit code, so we have to trust that it works
+    on_failure = continue
   }
 
   # Wait for MicroOS to reboot and be ready
   provisioner "local-exec" {
     command = <<-EOT
-      until ssh ${local.ssh_args} -o ConnectTimeout=2 root@${self.ipv4_address} true 2> /dev/null
+      sleep 5
+      until ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no -o PasswordAuthentication=no -o KbdInteractiveAuthentication=no -o ChallengeResponseAuthentication=no -o ConnectTimeout=2 ${self.ipv4_address}  2>&1 | grep "Permission denied"
       do
         echo "Waiting for MicroOS to reboot and become available..."
         sleep 2
       done
     EOT
   }
-
-
+  
   # Generating and uploading the agent.conf file
   provisioner "file" {
     content = templatefile("${path.module}/templates/agent.conf.tpl", {

--- a/locals.tf
+++ b/locals.tf
@@ -2,9 +2,9 @@ locals {
   first_control_plane_network_ip = cidrhost(hcloud_network_subnet.k3s.ip_range, 2)
   hcloud_image_name              = "ubuntu-20.04"
 
-  ssh_public_key = trimspace(file(var.public_key))
+  ssh_public_key = trimspace(var.public_key == null ? var.public_key_pem : file(var.public_key))
   # ssh_private_key is either the contents of var.private_key or null to use a ssh agent.
-  ssh_private_key = var.private_key == null ? null : trimspace(file(var.private_key))
+  ssh_private_key = var.private_key == null ? (var.private_key_pem == null ? null : trimspace(var.private_key_pem)): trimspace(file(var.private_key))
   # ssh_identity is not set if the private key is passed directly, but if ssh agent is used, the public key tells ssh agent which private key to use.
   # For terraforms provisioner.connection.agent_identity, we need the public key as a string.
   ssh_identity = var.private_key == null ? local.ssh_public_key : null
@@ -12,7 +12,7 @@ locals {
   # if an ssh agent is used.
   ssh_identity_file = var.private_key == null ? var.public_key : var.private_key
   # shared flags for ssh to ignore host keys, to use root and our ssh identity file for all connections during provisioning.
-  ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${local.ssh_identity_file}"
+  ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${local.ssh_identity_file == null ? "" : "-i ${local.ssh_identity_file}"}"
 
   ccm_version   = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm.release_tag
   csi_version   = var.hetzner_csi_version != null ? var.hetzner_csi_version : data.github_release.hetzner_csi.release_tag

--- a/master.tf
+++ b/master.tf
@@ -35,14 +35,20 @@ resource "hcloud_server" "first_control_plane" {
   }
 
   # Issue a reboot command
-  provisioner "local-exec" {
-    command = "ssh ${local.ssh_args} root@${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3"
+  provisioner "remote-exec" {
+    inline = [
+      "sleep 2",
+      "reboot"
+    ]
+    # reboot doesn't return a proper exit code, so we have to trust that it works
+    on_failure = continue
   }
 
   # Wait for MicroOS to reboot and be ready
   provisioner "local-exec" {
     command = <<-EOT
-      until ssh ${local.ssh_args} -o ConnectTimeout=2 root@${self.ipv4_address} true 2> /dev/null
+      sleep 3
+      until ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no -o PasswordAuthentication=no -o KbdInteractiveAuthentication=no -o ChallengeResponseAuthentication=no -o ConnectTimeout=2 ${self.ipv4_address}  2>&1 | grep "Permission denied"
       do
         echo "Waiting for MicroOS to reboot and become available..."
         sleep 2

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,8 +1,13 @@
 # You need to replace these
 hcloud_token = "xxxxxxxxxxxxxxxxxxYYYYYYYYYYYYYYYYYYYzzzzzzzzzzzzzzzzzzzzz"
+
+# public_key or public_key_pem has to be set
 public_key   = "/home/username/.ssh/id_ed25519.pub"
-# Must be "private_key = null" when you want to use ssh-agent, for a Yubikey like device auth or an SSH key-pair with passphrase
+public_key_pem = "ssh-rsa ...."
+
+# Must be "private_key = null" and "private_key_pem = null" when you want to use ssh-agent, for a Yubikey like device auth or an SSH key-pair with passphrase
 private_key  = "/home/username/.ssh/id_ed25519"
+private_key_pem = "-----BEGIN OPENSSH PRIVATE KEY----- ..."
 
 # These can be customized, or left with the default values
 # For Hetzner locations see https://docs.hetzner.com/general/others/data-centers-and-connection/

--- a/variables.tf
+++ b/variables.tf
@@ -7,11 +7,26 @@ variable "hcloud_token" {
 variable "public_key" {
   description = "SSH public Key."
   type        = string
+  default     = null
 }
 
 variable "private_key" {
   description = "SSH private Key."
   type        = string
+  default     = null
+}
+
+variable "public_key_pem" {
+  description = "SSH public Key in PEM format."
+  type        = string
+  default     = null
+}
+
+variable "private_key_pem" {
+  description = "SSH private Key in PEM format."
+  type        = string
+  sensitive   = true
+  default     = null
 }
 
 variable "location" {


### PR DESCRIPTION
Adds support for inline ssh public and private key.
With this change, we can generate the ssh key with https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key and pass it into the module.

This way the ssh keys don't have to be distributed between multiple engineers and the keys can be stored inside the state (Read the "Important Security Notice" in the `tls` documentation before storing your keys in the state)