### PR TITLE
adds functionality to add more public ssh keys

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -2,7 +2,7 @@ locals {
   first_control_plane_network_ip = cidrhost(hcloud_network_subnet.k3s.ip_range, 2)
   hcloud_image_name              = "ubuntu-20.04"
 
-  ssh_public_key = trimspace(file(var.public_key))
+  ssh_public_key  = trimspace(file(var.public_key))
   ssh_public_keys = concat(var.additional_public_keys, [local.ssh_public_key])
   # ssh_private_key is either the contents of var.private_key or null to use a ssh agent.
   ssh_private_key = var.private_key == null ? null : trimspace(file(var.private_key))

--- a/locals.tf
+++ b/locals.tf
@@ -3,6 +3,7 @@ locals {
   hcloud_image_name              = "ubuntu-20.04"
 
   ssh_public_key = trimspace(file(var.public_key))
+  ssh_public_keys = concat(var.additional_public_keys, [local.ssh_public_key])
   # ssh_private_key is either the contents of var.private_key or null to use a ssh agent.
   ssh_private_key = var.private_key == null ? null : trimspace(file(var.private_key))
   # ssh_identity is not set if the private key is passed directly, but if ssh agent is used, the public key tells ssh agent which private key to use.
@@ -17,6 +18,8 @@ locals {
   ccm_version   = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm.release_tag
   csi_version   = var.hetzner_csi_version != null ? var.hetzner_csi_version : data.github_release.hetzner_csi.release_tag
   kured_version = data.github_release.kured.release_tag
+
+  all_server_ips = concat([hcloud_server.first_control_plane.ipv4_address], hcloud_server.control_planes.*.ipv4_address, hcloud_server.agents.*.ipv4_address)
 
   MicroOS_install_commands = [
     "set -ex",

--- a/locals.tf
+++ b/locals.tf
@@ -19,8 +19,6 @@ locals {
   csi_version   = var.hetzner_csi_version != null ? var.hetzner_csi_version : data.github_release.hetzner_csi.release_tag
   kured_version = data.github_release.kured.release_tag
 
-  all_server_ips = concat([hcloud_server.first_control_plane.ipv4_address], hcloud_server.control_planes.*.ipv4_address, hcloud_server.agents.*.ipv4_address)
-
   MicroOS_install_commands = [
     "set -ex",
     "apt-get install -y aria2",

--- a/ssh_keys.tf
+++ b/ssh_keys.tf
@@ -1,11 +1,12 @@
-resource "null_resource" "add_ssh_keys" {
-  for_each = toset(local.all_server_ips)
+resource "null_resource" "add_ssh_keys_servers" {
+  count = var.servers_num - 1
 
   connection {
     user           = "root"
     private_key    = local.ssh_private_key
     agent_identity = local.ssh_identity
-    host           = each.value
+    host           = hcloud_server.control_planes[count.index].ipv4_address
+
   }
 
   provisioner "remote-exec" {
@@ -15,9 +16,57 @@ resource "null_resource" "add_ssh_keys" {
   }
 
   depends_on = [
-    "hcloud_server.first_control_plane",
-    "hcloud_server.control_planes",
-    "hcloud_server.agents"
+    hcloud_server.control_planes
+  ]
+
+  triggers = {
+    always_run = "${join("\n", local.ssh_public_keys)}"
+  }
+}
+
+resource "null_resource" "add_ssh_keys_first_control_plane" {
+  connection {
+    user           = "root"
+    private_key    = local.ssh_private_key
+    agent_identity = local.ssh_identity
+    host           = hcloud_server.first_control_plane.ipv4_address
+
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo '${join("\n", local.ssh_public_keys)}' > /root/.ssh/authorized_keys",
+    ]
+  }
+
+  depends_on = [
+    hcloud_server.first_control_plane
+  ]
+
+  triggers = {
+    always_run = "${join("\n", local.ssh_public_keys)}"
+  }
+}
+
+resource "null_resource" "add_ssh_keys_agents" {
+  count = var.agents_num
+
+  connection {
+    user           = "root"
+    private_key    = local.ssh_private_key
+    agent_identity = local.ssh_identity
+    host           = hcloud_server.agents[count.index].ipv4_address
+
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo '${join("\n", local.ssh_public_keys)}' > /root/.ssh/authorized_keys",
+    ]
+  }
+
+  depends_on = [
+    hcloud_server.agents
   ]
 
   triggers = {

--- a/ssh_keys.tf
+++ b/ssh_keys.tf
@@ -1,0 +1,26 @@
+resource "null_resource" "add_ssh_keys" {
+  for_each = toset(concat([hcloud_server.first_control_plane.ipv4_address], hcloud_server.control_planes.*.ipv4_address, hcloud_server.agents.*.ipv4_address))
+
+  connection {
+    user           = "root"
+    private_key    = local.ssh_private_key
+    agent_identity = local.ssh_identity
+    host           = each.value
+  }
+
+  provisioner "remote-exec" {
+    inline = [ 
+      "echo '${join("\n", concat(var.additional_public_keys, [local.ssh_public_key]))}' > /root/.ssh/authorized_keys",
+    ]
+  }
+
+  depends_on = [
+    "hcloud_server.first_control_plane",
+    "hcloud_server.control_planes",
+    "hcloud_server.agents"
+  ]
+
+  triggers = {
+    always_run = "${join("\n", concat(var.additional_public_keys, [local.ssh_public_key]))}"
+  }
+}

--- a/ssh_keys.tf
+++ b/ssh_keys.tf
@@ -1,5 +1,5 @@
 resource "null_resource" "add_ssh_keys" {
-  for_each = toset(concat([hcloud_server.first_control_plane.ipv4_address], hcloud_server.control_planes.*.ipv4_address, hcloud_server.agents.*.ipv4_address))
+  for_each = toset(local.all_server_ips)
 
   connection {
     user           = "root"
@@ -9,8 +9,8 @@ resource "null_resource" "add_ssh_keys" {
   }
 
   provisioner "remote-exec" {
-    inline = [ 
-      "echo '${join("\n", concat(var.additional_public_keys, [local.ssh_public_key]))}' > /root/.ssh/authorized_keys",
+    inline = [
+      "echo '${join("\n", local.ssh_public_keys)}' > /root/.ssh/authorized_keys",
     ]
   }
 
@@ -21,6 +21,6 @@ resource "null_resource" "add_ssh_keys" {
   ]
 
   triggers = {
-    always_run = "${join("\n", concat(var.additional_public_keys, [local.ssh_public_key]))}"
+    always_run = "${join("\n", local.ssh_public_keys)}"
   }
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,6 +1,8 @@
 # You need to replace these
 hcloud_token = "xxxxxxxxxxxxxxxxxxYYYYYYYYYYYYYYYYYYYzzzzzzzzzzzzzzzzzzzzz"
 public_key   = "/home/username/.ssh/id_ed25519.pub"
+# Allows to add more ssh public keys
+# additional_public_keys = [ "ssh-rsa ..." ]
 # Must be "private_key = null" when you want to use ssh-agent, for a Yubikey like device auth or an SSH key-pair with passphrase
 private_key  = "/home/username/.ssh/id_ed25519"
 

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,7 @@ variable "public_key" {
 variable "additional_public_keys" {
   description = "Additional SSH public Keys."
   type        = list(string)
+  default     = []
 }
 
 variable "private_key" {

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,11 @@ variable "public_key" {
   type        = string
 }
 
+variable "additional_public_keys" {
+  description = "Additional SSH public Keys."
+  type        = list(string)
+}
+
 variable "private_key" {
   description = "SSH private Key."
   type        = string


### PR DESCRIPTION
Replaces pull request #72

It doesn't support the same use case as #72 but accomplishes nearly the same feature in an easier way.
With this change we are able to add more than 1 ssh public key into the `authorized_hosts` file