### PR TITLE
Added documentation to use TLS with traefik

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,41 @@ _To turn off k3s upgrades, you can either set the `k3s_upgrade=true` label in th
 kubectl -n system-upgrade label node <node-name> k3s_upgrade-
 ```
 
+## Example Ingress with TLS
+
+Here is an example of an ingress to run an application with TLS, change the host to fit your need in `examples/tls/ingress.yaml` and then deploy the example
+```sh
+kubectl apply -f examples/tls/.
+```
+```yml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-ingress
+  annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.tls.certresolver: le
+spec:
+  tls:
+    - hosts:
+        - example.com
+      secretName: example-tls
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: nginx-service
+                port:
+                  number: 80
+
+
+```
+
+
 ## Takedown
 
 If you want to takedown the cluster, you can proceed as follows:

--- a/examples/tls/ingress.yaml
+++ b/examples/tls/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-ingress
+  annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.tls.certresolver: le
+spec:
+  tls:
+    - hosts:
+        - example.com
+      secretName: example-tls
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: nginx-service
+                port:
+                  number: 80
+

--- a/examples/tls/pod.yaml
+++ b/examples/tls/pod.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: nginx
+  name: nginx
+spec:
+  containers:
+  - image: nginx
+    name: nginx
+    ports:
+    - containerPort: 80
+

--- a/examples/tls/service.yaml
+++ b/examples/tls/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    run: nginx


### PR DESCRIPTION
Here's  the tested documentation to quickly spin up an nginx pod with TLS, as asked here https://github.com/kube-hetzner/kube-hetzner/pull/37#issuecomment-1037554173

I'm just not sure about the subdomains part, I usually use one certificate per subdomain, 