### PR TITLE
Expose load balancer ip

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -156,19 +156,5 @@ resource "hcloud_placement_group" "k3s" {
 data "hcloud_load_balancer" "traefik" {
   name = "traefik"
 
-  depends_on = [null_resource.cluster_provisioning]
-}
-
-
-resource "null_resource" "cluster_provisioning" {
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = <<-EOT
-      hcloud load-balancer delete traefik
-      hcloud network delete k3s
-    EOT
-  }
-
   depends_on = [null_resource.first_control_plane]
 }

--- a/main.tf
+++ b/main.tf
@@ -162,34 +162,13 @@ data "hcloud_load_balancer" "traefik" {
 
 resource "null_resource" "cluster_provisioning" {
 
-  triggers = {
-    agent_ids         = "${join(",", module.agents.*.id)}"
-    control_plane_ids = "${join(",", concat([module.first_control_plane.id], module.control_planes.*.id))}"
-  }
-
-  depends_on = [null_resource.first_control_plane, null_resource.control_planes, null_resource.agents]
-
-  provisioner "remote-exec" {
-    connection {
-      user           = "root"
-      private_key    = local.ssh_private_key
-      agent_identity = local.ssh_identity
-      host           = module.first_control_plane.ipv4_address
-    }
-
-    inline = [
-      <<-EOT
-      timeout 120 bash <<EOF
-      until [ -n "\$(kubectl get -n kube-system service/traefik --output=jsonpath='{.status.loadBalancer.ingress[0].ip}')" ]; do
-          echo "Waiting for load-balancer to get an IP..."
-      done
-      EOF
-      EOT
-    ]
-  }
-
   provisioner "local-exec" {
     when    = destroy
-    command = "hcloud load-balancer delete traefik"
+    command = <<-EOT
+      hcloud load-balancer delete traefik
+      hcloud network delete k3s
+    EOT
   }
+
+  depends_on = [null_resource.first_control_plane]
 }

--- a/main.tf
+++ b/main.tf
@@ -167,7 +167,7 @@ resource "null_resource" "cluster_provisioning" {
     control_plane_ids = "${join(",", concat([module.first_control_plane.id], module.control_planes.*.id))}"
   }
 
-  depends_on = [ null_resource.first_control_plane, null_resource.control_planes, null_resource.agents ]
+  depends_on = [null_resource.first_control_plane, null_resource.control_planes, null_resource.agents]
 
   provisioner "remote-exec" {
     connection {
@@ -189,7 +189,7 @@ resource "null_resource" "cluster_provisioning" {
   }
 
   provisioner "local-exec" {
-    when = destroy
+    when    = destroy
     command = "hcloud load-balancer delete traefik"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -153,10 +153,8 @@ resource "hcloud_placement_group" "k3s" {
   }
 }
 
-/* 
 data "hcloud_load_balancer" "traefik" {
   name = "traefik"
 
-  depends_on = [hcloud_server.agents[0]]
+  depends_on = [module.first_control_plane]
 }
-*/

--- a/master.tf
+++ b/master.tf
@@ -157,7 +157,14 @@ resource "null_resource" "first_control_plane" {
       "kubectl apply -k /tmp/post_install",
       "echo 'Waiting for the system-upgrade-controller deployment to become available...'",
       "kubectl -n system-upgrade wait --for=condition=available --timeout=120s deployment/system-upgrade-controller",
-      "kubectl -n system-upgrade apply -f /tmp/post_install/plans.yaml"
+      "kubectl -n system-upgrade apply -f /tmp/post_install/plans.yaml",
+      <<-EOT
+      timeout 120 bash <<EOF
+      until [ -n "\$(kubectl get -n kube-system service/traefik --output=jsonpath='{.status.loadBalancer.ingress[0].ip}')" ]; do
+          echo "Waiting for load-balancer to get an IP..."
+      done
+      EOF
+      EOT
     ]
   }
 

--- a/master.tf
+++ b/master.tf
@@ -157,14 +157,7 @@ resource "null_resource" "first_control_plane" {
       "kubectl apply -k /tmp/post_install",
       "echo 'Waiting for the system-upgrade-controller deployment to become available...'",
       "kubectl -n system-upgrade wait --for=condition=available --timeout=120s deployment/system-upgrade-controller",
-      "kubectl -n system-upgrade apply -f /tmp/post_install/plans.yaml",
-      <<-EOT
-      timeout 120 bash <<EOF
-      until [ -n "\$(kubectl get -n kube-system service/traefik --output=jsonpath='{.status.loadBalancer.ingress[0].ip}')" ]; do
-          echo "Waiting for load-balancer to get an IP..."
-      done
-      EOF
-      EOT
+      "kubectl -n system-upgrade apply -f /tmp/post_install/plans.yaml"
     ]
   }
 

--- a/master.tf
+++ b/master.tf
@@ -157,7 +157,15 @@ resource "null_resource" "first_control_plane" {
       "kubectl apply -k /tmp/post_install",
       "echo 'Waiting for the system-upgrade-controller deployment to become available...'",
       "kubectl -n system-upgrade wait --for=condition=available --timeout=120s deployment/system-upgrade-controller",
-      "kubectl -n system-upgrade apply -f /tmp/post_install/plans.yaml"
+      "kubectl -n system-upgrade apply -f /tmp/post_install/plans.yaml",
+      <<-EOT
+      timeout 120 bash <<EOF
+      until [ -n "\$(kubectl get -n kube-system service/traefik --output=jsonpath='{.status.loadBalancer.ingress[0].ip}' 2> /dev/null)" ]; do
+          echo "Waiting for load-balancer to get an IP..."
+          sleep 2
+      done
+      EOF
+      EOT
     ]
   }
 

--- a/output.tf
+++ b/output.tf
@@ -8,12 +8,10 @@ output "agents_public_ip" {
   description = "The public IP addresses of the agent server."
 }
 
-/* 
 output "load_balancer_public_ip" {
   description = "The public IPv4 address of the Hetzner load balancer"
   value       = data.hcloud_load_balancer.traefik.ipv4
 }
-*/
 
 output "kubeconfig_file" {
   value       = local.kubeconfig_external


### PR DESCRIPTION
This is the same as #69, but this time we explicitly wait until the `traefik` service exists and has an ingress ip set (which means that the load-balancer has been deployed by hetzner CCM).

The extra `null_resource` seems to be necessary because traefik does not start until the cluster is fully operational, which it isn't with just a single node. It might be sufficient to depend only on the control planes, but I did not test that explictly.

We also run `hcloud load-balancer delete traefik` locally on destroy, which seems to be sufficient to make the destruction of hcloud_network.k3s work as expected.

Please tell me if I've missed yet another edge case, @mnencia and @mysticaltech ;)
