### PR TITLE
Update agents.tf

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -13,7 +13,7 @@ module "agents" {
   location               = var.location
   network_id             = hcloud_network.k3s.id
   ip                     = cidrhost(hcloud_network_subnet.k3s.ip_range, 513 + count.index)
-  server_type            = var.control_plane_server_type
+  server_type            = var.agent_server_type
 
   labels = {
     "provisioner" = "terraform",


### PR DESCRIPTION
Ensuring the right agent server type is attaching - I tore down and rebuilt my cluster and was noticing that only the control plane server type was being honored from the tfvars.