### PR TITLE
Auto destroy LB on terraform destroy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -159,19 +159,29 @@ data "hcloud_load_balancer" "traefik" {
   depends_on = [null_resource.kustomization]
 }
 
-resource "null_resource" "destroy_lb" {
+
+resource "null_resource" "destroy_traefik_loadbalancer" {
+  # this only gets triggered before total destruction of the cluster, but when the necessary elements to run the commands are still available
   triggers = {
-    token = random_password.k3s_token.result
+    kustomization_id = null_resource.kustomization.id
   }
 
   # Important when issuing terraform destroy, otherwise the LB will not let the network get deleted
   provisioner "local-exec" {
-    when    = destroy
-    command = <<-EOT
-      hcloud load-balancer delete traefik
-      hcloud network delete k3s
+    when       = destroy
+    command    = <<-EOT
+      kubectl -n kube-system delete service traefik --kubeconfig ${path.module}/kubeconfig.yaml
     EOT
-
     on_failure = continue
   }
+
+  depends_on = [
+    local_file.kubeconfig,
+    null_resource.control_planes[0],
+    hcloud_network_subnet.k3s,
+    hcloud_network.k3s,
+    hcloud_firewall.k3s,
+    hcloud_placement_group.k3s,
+    hcloud_ssh_key.k3s
+  ]
 }

--- a/main.tf
+++ b/main.tf
@@ -158,3 +158,20 @@ data "hcloud_load_balancer" "traefik" {
 
   depends_on = [null_resource.kustomization]
 }
+
+resource "null_resource" "destroy_lb" {
+  triggers = {
+    token = random_password.k3s_token.result
+  }
+
+  # Important when issuing terraform destroy, otherwise the LB will not let the network get deleted
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<-EOT
+      hcloud load-balancer delete traefik
+      hcloud network delete k3s
+    EOT
+
+    on_failure = continue
+  }
+}

--- a/modules/host/locals.tf
+++ b/modules/host/locals.tf
@@ -65,8 +65,7 @@ locals {
 rpm --import https://rpm.rancher.io/public.key
 zypper refresh
 zypper --gpg-auto-import-keys install -y https://rpm.rancher.io/k3s/stable/common/microos/noarch/k3s-selinux-0.4-1.sle.noarch.rpm
-udevadm settle
-exit 0
+udevadm settle || true
 EOF
 
 }

--- a/modules/host/locals.tf
+++ b/modules/host/locals.tf
@@ -66,6 +66,7 @@ rpm --import https://rpm.rancher.io/public.key
 zypper refresh
 zypper --gpg-auto-import-keys install -y https://rpm.rancher.io/k3s/stable/common/microos/noarch/k3s-selinux-0.4-1.sle.noarch.rpm
 udevadm settle
+exit 0
 EOF
 
 }


### PR DESCRIPTION
Hey folks, this build-up on the good work of @phaer in previous commits.

It was achieved with a simple null resource that triggers on the change of the token, and my testing indicated that it's also necessary to delete the network.

The end result is that it works well and the destroy is smooth. Even in the case of an eventual error, it will continue, if the LB was not there for instance, or the hcloud command was not installed.

![ksnip_20220224-014430](https://user-images.githubusercontent.com/518555/155436068-64b13c11-1fba-4c21-b4cb-8ce812b64779.png)


