### PR TITLE
Remove secret from TLS example

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ spec:
   tls:
     - hosts:
         - example.com
-      secretName: example-tls
   rules:
     - host: example.com
       http:

--- a/examples/tls/ingress.yaml
+++ b/examples/tls/ingress.yaml
@@ -9,7 +9,6 @@ spec:
   tls:
     - hosts:
         - example.com
-      secretName: example-tls
   rules:
     - host: example.com
       http:


### PR DESCRIPTION
This removes the secret from the TLS example. Otherwise you'll get errors that the secret does not exist, see #109.