### PR TITLE
Changed the cluster name to manual

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -3,7 +3,7 @@ module "agents" {
 
   for_each = local.agent_nodepools
 
-  name                   = "${var.use_cluster_name_in_node_name ? "${random_pet.cluster.id}-" : ""}${each.value.nodepool_name}"
+  name                   = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
   ssh_keys               = [hcloud_ssh_key.k3s.id]
   public_key             = var.public_key
   private_key            = var.private_key

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -2,7 +2,7 @@ module "control_planes" {
   source = "./modules/host"
 
   count                  = var.control_plane_count
-  name                   = "${var.use_cluster_name_in_node_name ? "${random_pet.cluster.id}-" : ""}control-plane"
+  name                   = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}control-plane"
   ssh_keys               = [hcloud_ssh_key.k3s.id]
   public_key             = var.public_key
   private_key            = var.private_key

--- a/init.tf
+++ b/init.tf
@@ -94,7 +94,7 @@ resource "null_resource" "kustomization" {
     content = local.is_single_node_cluster ? "" : templatefile(
       "${path.module}/templates/traefik_config.yaml.tpl",
       {
-        name                       = "${random_pet.cluster.id}-traefik"
+        name                       = "${var.cluster_name}-traefik"
         load_balancer_disable_ipv6 = var.load_balancer_disable_ipv6
         load_balancer_type         = var.load_balancer_type
         location                   = var.location

--- a/main.tf
+++ b/main.tf
@@ -1,20 +1,15 @@
-resource "random_pet" "cluster" {
-  length = 1
-  prefix = var.cluster_prefix
-}
-
 resource "random_password" "k3s_token" {
   length  = 48
   special = false
 }
 
 resource "hcloud_ssh_key" "k3s" {
-  name       = random_pet.cluster.id
+  name       = var.cluster_name
   public_key = local.ssh_public_key
 }
 
 resource "hcloud_network" "k3s" {
-  name     = random_pet.cluster.id
+  name     = var.cluster_name
   ip_range = var.network_ipv4_range
 }
 
@@ -37,7 +32,7 @@ resource "hcloud_network_subnet" "subnet" {
 }
 
 resource "hcloud_firewall" "k3s" {
-  name = random_pet.cluster.id
+  name = var.cluster_name
 
   dynamic "rule" {
     for_each = concat(local.base_firewall_rules, var.extra_firewall_rules)
@@ -52,7 +47,7 @@ resource "hcloud_firewall" "k3s" {
 }
 
 resource "hcloud_placement_group" "k3s" {
-  name = random_pet.cluster.id
+  name = var.cluster_name
   type = "spread"
   labels = {
     "provisioner" = "terraform",
@@ -62,7 +57,7 @@ resource "hcloud_placement_group" "k3s" {
 
 data "hcloud_load_balancer" "traefik" {
   count = local.is_single_node_cluster ? 0 : 1
-  name  = "${random_pet.cluster.id}-traefik"
+  name  = "${var.cluster_name}-traefik"
 
   depends_on = [null_resource.kustomization]
 }

--- a/output.tf
+++ b/output.tf
@@ -1,5 +1,5 @@
 output "cluster_name" {
-  value       = random_pet.cluster.id
+  value       = var.cluster_name
   description = "Shared suffix for all resources belonging to this cluster."
 }
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -77,11 +77,11 @@ load_balancer_type        = "lb11"
 # Allows you to specify either stable, latest, or testing (defaults to stable), see https://rancher.com/docs/k3s/latest/en/upgrades/basic/
 # initial_k3s_channel = "latest"
 
-# Whether to use the cluster name in the node name, i.e. add the prefix k3s-(cluster_name)- to the nodes? The default is "true".
+# Whether to use the cluster name to in the node name, the default is true
 # use_cluster_name_in_node_name = false
 
-# Prefix for the cluster name, by default "k3s"
-# cluster_prefix = ""
+# The cluster name, by default "k3s"
+# cluster_name = ""
 
 # Adding extra firewall rules, like opening a port
 # In this example with allow port TCP 5432 for a Postgres service we will open via a nodeport

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -77,7 +77,7 @@ load_balancer_type        = "lb11"
 # Allows you to specify either stable, latest, or testing (defaults to stable), see https://rancher.com/docs/k3s/latest/en/upgrades/basic/
 # initial_k3s_channel = "latest"
 
-# Whether to use the cluster name to in the node name, the default is true
+# Whether to use the cluster name in the node name, the default is "true".
 # use_cluster_name_in_node_name = false
 
 # The cluster name, by default "k3s"

--- a/variables.tf
+++ b/variables.tf
@@ -127,10 +127,15 @@ variable "use_cluster_name_in_node_name" {
   description = "Whether to use the cluster name in the node name"
 }
 
-variable "cluster_prefix" {
+variable "cluster_name" {
   type        = string
   default     = "k3s"
-  description = "Prefix for the cluster name"
+  description = "Name of the cluster"
+
+  validation {
+    condition     = can(regex("^[a-z1-9\\-]+$", var.cluster_name))
+    error_message = "The cluster name must be in the form of lowercase alphanumeric characters and/or dashes."
+  }
 }
 
 variable "traefik_additional_options" {


### PR DESCRIPTION
The automatic pet name for both the cluster and nodes felt like overkill and I did not feel comfortable with them. Now setting the cluster name manually makes more sense, as the cluster is here to stay, its name can be meaningful. As the random pets are really random and meaningless, that suits more the ephemeral nature of nodes.

It defaults to "k3s" but can be anything like "k3s-cluster-xyz" as long as it is hostname compatible. It has the right checks for that.