### PR TITLE
automatically publish releases for tags, switch to dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,22 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: Bug Fixes 🐛
+      labels:
+        - Semver-Patch
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/publish-terraform.yaml
+++ b/.github/workflows/publish-terraform.yaml
@@ -1,0 +1,19 @@
+---
+name: Publish a new Github Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  Release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          name: 'v${{ github.ref_name }}'
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-terraform.yaml
+++ b/.github/workflows/publish-terraform.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ncipollo/release-action@v1
         with:
           generateReleaseNotes: true

--- a/.github/workflows/validate-terraform.yaml
+++ b/.github/workflows/validate-terraform.yaml
@@ -1,5 +1,5 @@
 ---
-name: Terraform
+name: Validate Terraform
 
 on:
   push:

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["config:base", ":disableDependencyDashboard"]
-}


### PR DESCRIPTION
Hi,

This does 3 things:
* Switch from renovate to dependabot. I hadn't noticed that dependabot has become part of github, so I'd just use that one for updates. github actions and terraform modules are included. See [docs](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) or [my repo for an example of logs](https://github.com/phaer/kube-hetzner/network/updates).
* Use https://github.com/ncipollo/release-action to automatically generate a release whenever a tag is pushed. (the tag should **not** include a "v" prefix, as that one will be added by the action). Once our terraform registry project is set up, a webhook will be triggered upon release to upload the release to registry.terraform.io. 
* Additionally, a changelog is auto-generated based on PR since the last release and their labels. This is somewhat experimental from my point of view and we might need to further adapt it to our workflow going forward. [docs](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)

While I did similar things before with gitlab CI, I am pretty new to github actions, so please review & let me know what you think!